### PR TITLE
benchmarkの追加

### DIFF
--- a/roles/benchmark/tasks/main.yml
+++ b/roles/benchmark/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: create benchmark directory
   file:
-    path: {{ ansible_env.PWD }}/../benchmark
+    path: "{{ ansible_env.PWD }}/../benchmark"
     state: directory
     owner: root
     group: root
@@ -9,7 +9,7 @@
 
 - name: add benchmark scripts
   template: 
-    src: {{ items }}
-    dest: {{ ansible_env.PWD }}/../benchmark
-    with_items:
-      - alp.sh
+    src: "{{ item }}"
+    dest: "{{ ansible_env.PWD }}/../benchmark"
+  with_items:
+    - alp.sh

--- a/roles/benchmark/tasks/main.yml
+++ b/roles/benchmark/tasks/main.yml
@@ -5,7 +5,7 @@
     state: directory
     owner: root
     group: root
-    mode: 075
+    mode: 0755
 
 - name: add benchmark scripts
   template: 

--- a/roles/benchmark/tasks/main.yml
+++ b/roles/benchmark/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: create benchmark directory
+  file:
+    path: {{ ansible_env.PWD }}/../benchmark
+    state: directory
+    owner: root
+    group: root
+    mode: 075
+
+- name: add benchmark scripts
+  template: 
+    src: {{ items }}
+    dest: {{ ansible_env.PWD }}/../benchmark
+    with_items:
+      - alp.sh

--- a/roles/benchmark/templates/alp.sh
+++ b/roles/benchmark/templates/alp.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+alp -f /tmp/nginx_access.log --sum -r | slackcat --channel bench

--- a/site.yml
+++ b/site.yml
@@ -7,3 +7,4 @@
     - nginx
     - pt-query-digest
     - slackcat
+    - benchmark


### PR DESCRIPTION
profiler_ansibleと同階層にbenchmarkというディレクトリを作成し、そこにベンチマーク算出系処理のスクリプトを配置するroleを追加。